### PR TITLE
Axis parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Just use the **dc_motor** macro in a descriptor file as if it were a joint:
   <xacro:dc_motor motor_name="dc_motor" parent_link="base_link" child_link="wheel_link">
     <xacro:property name="params_yaml" value="$(find gazebo_ros_motors)/params/dc_motor.yaml"/>
     <origin xyz="0 0 0.2" rpy="0 0 0"/>
+    <axis xyz="0 1 0" rpy="0 0 0"/>
   </xacro:dc_motor>
 ```
 
@@ -142,6 +143,7 @@ Just use the **joint_motor** macro in a descriptor file as if it were a joint:
   <xacro:joint_motor motor_name="ode_motor" parent_link="base_link" child_link="wheel_link">
     <xacro:property name="params_yaml" value="$(find gazebo_ros_motors)/params/joint_motor.yaml"/>
     <origin xyz="0 0 0.2" rpy="0 0 0"/>
+    <axis xyz="0 0 1" rpy="0 0 0"/>
   </xacro:joint_motor>
 ```
 

--- a/xacro/dc_motor.xacro
+++ b/xacro/dc_motor.xacro
@@ -1,21 +1,22 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-<xacro:macro name="dc_motor" params="motor_name parent_link child_link *origin">
+<xacro:macro name="dc_motor" params="motor_name parent_link child_link *origin *axis">
   <!-- <xacro:property name="params_yaml" value="$(find gazebo_ros_motors)/params/dc_motor.yaml"/> -->
   <xacro:property name="motor_param" value="${load_yaml(params_yaml)}"/>
   <joint name="${motor_name}" type="continuous">
       <parent link="${parent_link}"/>
       <child link="${child_link}"/>
       <xacro:insert_block name="origin"/>
-      <axis xyz="0 0 1"/>
+      <xacro:insert_block name="axis"/>
+      <!-- <axis xyz="0 0 1"/> -->
       <dynamics damping="${motor_param['joint_damping']}" friction="${motor_param['joint_friction']}"/>
   </joint>
   <gazebo reference="${motor_name}">
     <provideFeedback>true</provideFeedback>
   </gazebo>
   <gazebo>
-    <plugin name="motor_plugin" filename="libgazebo_ros_dc_motor.so">
+    <plugin name="${motor_name}_plugin" filename="libgazebo_ros_dc_motor.so">
       <motor_shaft_joint>${motor_name}</motor_shaft_joint>
       <motor_wrench_frame>${child_link}</motor_wrench_frame>
       <command_topic>${motor_name}/command</command_topic>

--- a/xacro/dc_motor.xacro
+++ b/xacro/dc_motor.xacro
@@ -9,7 +9,6 @@
       <child link="${child_link}"/>
       <xacro:insert_block name="origin"/>
       <xacro:insert_block name="axis"/>
-      <!-- <axis xyz="0 0 1"/> -->
       <dynamics damping="${motor_param['joint_damping']}" friction="${motor_param['joint_friction']}"/>
   </joint>
   <gazebo reference="${motor_name}">

--- a/xacro/joint_motor.xacro
+++ b/xacro/joint_motor.xacro
@@ -1,14 +1,14 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-<xacro:macro name="joint_motor" params="motor_name parent_link child_link *origin">
+<xacro:macro name="joint_motor" params="motor_name parent_link child_link *origin *axis">
   <xacro:property name="params_yaml"  value="$(find gazebo_ros_motors)/params/joint_motor.yaml"/>
   <xacro:property name="motor_param" value="${load_yaml(params_yaml)}"/>
   <joint name="${motor_name}" type="continuous">
       <parent link="${parent_link}"/>
       <child link="${child_link}"/>
       <xacro:insert_block name="origin"/>
-      <axis xyz="0 0 1"/>
+      <xacro:insert_block name="axis"/>
       <dynamics damping="${motor_param['joint_damping']}" friction="${motor_param['joint_friction']}"/>
   </joint>
   <gazebo>

--- a/xacro/joint_motor.xacro
+++ b/xacro/joint_motor.xacro
@@ -12,7 +12,7 @@
       <dynamics damping="${motor_param['joint_damping']}" friction="${motor_param['joint_friction']}"/>
   </joint>
   <gazebo>
-    <plugin name="motor_plugin" filename="libgazebo_ros_joint_motor.so">
+    <plugin name="${motor_name}_plugin" filename="libgazebo_ros_joint_motor.so">
       <motor_shaft_joint>${motor_name}</motor_shaft_joint>
       <motor_wrench_frame>${child_link}</motor_wrench_frame>
       <ode_joint_motor_fmax>${motor_param['ode_joint_motor_fmax']}</ode_joint_motor_fmax>


### PR DESCRIPTION
Close #7 
- `axis` parameter can now be passed
- changed `plugin name` to include `motor_name` so that multiple plugins can be used within the same `xacro`